### PR TITLE
Added default value override for FAQ sort order meta field

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: ucfwebcom
 Requires at least: 5.3
 Tested up to: 5.3
 Stable tag: 0.0.0
-Requires PHP: 7.4
+Requires PHP: 7.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: ucfwebcom
 Requires at least: 5.3
 Tested up to: 5.3
 Stable tag: 0.0.0
-Requires PHP: 7.0
+Requires PHP: 7.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html
 

--- a/plugin-filters/faq.php
+++ b/plugin-filters/faq.php
@@ -1,11 +1,17 @@
 <?php
 /**
- * Overrides to the FAQ plugin for the Safety site
+ * Overrides to the UCF FAQ plugin for the Safety site
  */
 
 namespace Safety\Utils\Plugins;
 
 
+/**
+ * Modifies registered ACF Fields in the UCF FAQ plugin.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
 function faq_acf_fields() {
 	// Can't get a local field, return.
 	if ( ! function_exists( 'acf_get_local_field' ) ) return;

--- a/plugin-filters/faq.php
+++ b/plugin-filters/faq.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Overrides to the FAQ plugin for the Safety site
+ */
+
+namespace Safety\Utils\Plugins;
+
+
+function faq_acf_fields() {
+	// Can't get a local field, return.
+	if ( ! function_exists( 'acf_get_local_field' ) ) return;
+
+	$sort_order_key = 'field_5b917a3820356';
+	$sort_order_field = acf_get_local_field( $sort_order_key );
+	if ( ! $sort_order_field ) return;
+
+	// Modify existing sort order field settings to force
+	// a default value.
+	$sort_order_field['default_value'] = 99999;
+	acf_remove_local_field( $sort_order_key );
+	acf_add_local_field( $sort_order_field );
+}
+
+add_action( 'acf/init', __NAMESPACE__ . '\faq_acf_fields', 11, 0 );

--- a/safety-utilities.php
+++ b/safety-utilities.php
@@ -11,3 +11,11 @@ GitHub Plugin URI: UCF/Safety-Utilities
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
+
+define( 'UCF_SAFETY_UTILS__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
+define( 'UCF_SAFETY_UTILS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'UCF_SAFETY_UTILS__STATIC_URL', UCF_SAFETY_UTILS__PLUGIN_URL . '/static' );
+define( 'UCF_SAFETY_UTILS__PLUGIN_FILE', __FILE__ );
+
+
+require_once UCF_SAFETY_UTILS__PLUGIN_DIR . 'plugin-filters/faq.php';


### PR DESCRIPTION
<!---
Thank you for contributing to Safety-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Safety-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Safety site content editors require FAQ ordering that pushes FAQs without a sort order value toward the bottom of FAQ lists, not toward the top (by default, unordered FAQs are displayed first).  New FAQs will now have a high sort order value by default with this update, pushing them to the end of FAQ lists.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
